### PR TITLE
Add bouquet-android to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ A collection of tools, apps and other stuff for using the nsite spec (NIP-5A) wh
 - [nsyte](https://github.com/sandwichfarm/nsyte) CLI deployment tool
 - [nsite-action](https://github.com/sandwichfarm/nsite-action) A Github action that deploys nsites to nostr and blossom (using nsyte)
 - [nsite debugger](https://nsite.info/debug) A tool to debug nsites.
+- [bouquet-android](https://github.com/kengirie/bouquet-android) Android app for viewing nsites, communicating directly with relays and Blossom
 
 ## Available nsite hosts / gateways
 


### PR DESCRIPTION
I made Bouquet, an Android app for viewing nsites without a gateway, so I would like to add it to the Tools section.
It does not depend on a smart-server. Instead, the app connects directly to relays and Blossom servers, gets the NIP-5A manifest and blobs on the device, checks the SHA-256 of each blob, and shows the site in a hardened in-app WebView.